### PR TITLE
Fix responsive sizing init and update label

### DIFF
--- a/src/runtime/translations/default.ts
+++ b/src/runtime/translations/default.ts
@@ -1,3 +1,3 @@
 export default {
-    _widgetLabel: 'SVG Icon'
+    _widgetLabel: 'SVG Icon 2'
 }


### PR DESCRIPTION
## Summary
- convert the base icon size helper to a class method so the initial state can call it safely
- keep the resize observer responsive sizing logic intact without triggering runtime errors
- rename the runtime widget label translation to "SVG Icon 2" so the menu entry matches the manifest

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68cda62623948330bd25882be543ffda